### PR TITLE
OS X compatiblity

### DIFF
--- a/libuuid/main.rkt
+++ b/libuuid/main.rkt
@@ -18,7 +18,12 @@
     (uuid? predicate/c)))
 
 
-(define-ffi-definer define-uuid (ffi-lib "libuuid" '("1" "")))
+(define which-lib
+  (case (system-type 'os)
+    [(macosx) "libSystem"]
+    [else "libuuid"]))
+
+(define-ffi-definer define-uuid (ffi-lib which-lib '("1" "")))
 
 
 (define (uuid? str)


### PR DESCRIPTION
Use libSystem instead of libuuid on OS X, since it provides the same functions but does not incur additional dependencies.
