### PR TITLE
build documentation during 'raco setup'

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -3,5 +3,6 @@
 (define collection 'multi)
 (define deps '("base"))
 (define build-deps '("racket-doc" "scribble-lib"))
+(define scribblings '(("libuuid/libuuid.scrbl")))
 
 ; vim:set ts=2 sw=2 et:


### PR DESCRIPTION
Add 'scribblings' entry to the 'info.rkt' file, so `raco setup libuuid` builds & renders the documentation.